### PR TITLE
Fix issue in MultipleModelUtil.js

### DIFF
--- a/MultipleModelUtil.js
+++ b/MultipleModelUtil.js
@@ -19,10 +19,10 @@
 //
 
 const MultipleModelAlignmentType = {
-  CenterToCenter: 0,
-  OriginToOrigin: 1,
-  ShareCoordinates: 2,
-  Custom: 3
+  CenterToCenter: 1,
+  OriginToOrigin: 2,
+  ShareCoordinates: 3,
+  Custom: 4
 };
 
 class MultipleModelUtil {


### PR DESCRIPTION
There's an issue wih using 0 as key to CenterToCenter in MultipleModelAlignmentType, specifically in the function `#isValidOptions(opts)`, 
The following condition will always be true therefore return false as !opts.alignment will always be true when opts.alignment = 0

` if (!opts || !opts.alignment || !Object.values(MultipleModelAlignmentType).includes(opts.alignment)) return false;`

Proposed solution, change MultipleModelAlignmentType definition to:
`const MultipleModelAlignmentType = {
  CenterToCenter: 1,
  OriginToOrigin: 2,
  ShareCoordinates: 3,
  Custom: 4
};`